### PR TITLE
Soft delete users and their listings

### DIFF
--- a/SPs/UserSps/DeleteUser.sql
+++ b/SPs/UserSps/DeleteUser.sql
@@ -2,9 +2,11 @@ DELIMITER //
 
 /*---------------------------------------------------------------
   SP: DeleteUser
-  Propósito: "Eliminar" un usuario (borrado lógico).
-    - Verifica que el usuario exista y no esté ya eliminado (status ≠ -1).
-    - Cambia status a -1.
+  Propósito: Realiza una eliminación lógica del usuario y sus publicaciones.
+    - Verifica que el usuario exista y no esté eliminado.
+    - Marca al usuario con status = -1.
+    - Marca sus publicaciones con status = -1.
+    - Borra las imágenes auxiliares de dichas publicaciones.
 ----------------------------------------------------------------*/
 DROP PROCEDURE IF EXISTS DeleteUser//
 
@@ -12,7 +14,7 @@ CREATE PROCEDURE DeleteUser(
   IN p_UserId BIGINT
 )
 BEGIN
-  -- Verificar que el usuario exista y no esté eliminado (status ≠ -1)
+  -- Verificar que el usuario exista y no esté eliminado
   IF NOT EXISTS (
     SELECT 1 FROM users WHERE id = p_UserId AND status <> -1
   ) THEN
@@ -21,12 +23,23 @@ BEGIN
 
   START TRANSACTION;
 
-  -- Marcar como eliminado lógicamente
-  UPDATE users
-    SET status = -1
-  WHERE id = p_UserId;
+  -- Marcar publicaciones del usuario como eliminadas
+  UPDATE listings
+     SET status = -1
+   WHERE user_id = p_UserId;
 
-  -- Si no se actualizó ninguna fila, hay un error
+  -- Borrar imágenes auxiliares de sus publicaciones
+  DELETE FROM listing_images
+   WHERE listing_id IN (
+           SELECT id FROM listings WHERE user_id = p_UserId
+         );
+
+  -- Marcar al usuario como eliminado
+  UPDATE users
+     SET status = -1
+   WHERE id = p_UserId;
+
+  -- Verificar que se actualizó el usuario
   IF ROW_COUNT() = 0 THEN
     ROLLBACK;
     SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Error al eliminar usuario';
@@ -37,7 +50,7 @@ BEGIN
   -- Devolver resultado
   SELECT
     0 AS code,
-    'Usuario eliminado' AS description;
+    'Usuario desactivado, publicaciones e imágenes eliminadas' AS description;
 END//
 
 DELIMITER ;


### PR DESCRIPTION
## Summary
- Make `DeleteUser` perform a logical deletion for users
- Mark user listings as deleted and remove their auxiliary images

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890ea12889083308e994c466605ef1d