### PR TITLE
Store residence proof data with email confirmation

### DIFF
--- a/SPs/UserSps/CreateUser.sql
+++ b/SPs/UserSps/CreateUser.sql
@@ -4,7 +4,6 @@ DELIMITER //
   SP: CreateUser
   Propósito:
     - Crear un nuevo usuario.
-    - Insertar opcionalmente su comprobante de residencia.
     - Devolver el registro del usuario.
 ----------------------------------------------------------------*/
 DROP PROCEDURE IF EXISTS CreateUser//
@@ -16,9 +15,7 @@ CREATE PROCEDURE CreateUser(
   IN p_PasswordHash  VARCHAR(255),
   IN p_Dni           VARCHAR(20),
   IN p_CountryId     BIGINT,
-  IN p_Phone         VARCHAR(20),
-  IN p_ProofMessage  TEXT,
-  IN p_ProofImageB64 LONGTEXT
+  IN p_Phone         VARCHAR(20)
 )
 BEGIN
   DECLARE v_NewUserId BIGINT;
@@ -50,15 +47,6 @@ BEGIN
       0,      NOW()
     );
     SET v_NewUserId = LAST_INSERT_ID();
-
-    -- Si envían comprobante de residencia, lo insertamos
-    IF p_ProofMessage IS NOT NULL OR p_ProofImageB64 IS NOT NULL THEN
-      INSERT INTO residence_proofs (
-        user_id, proof_message, proof_image_b64, created_at
-      ) VALUES (
-        v_NewUserId, p_ProofMessage, p_ProofImageB64, NOW()
-      );
-    END IF;
   COMMIT;
 
   -- Devolver el usuario creado
@@ -74,7 +62,7 @@ BEGIN
     0                     AS verified_residence,
     0                     AS status,
     p_CountryId           AS country_id,
-    p_ProofImageB64       AS profile_picture,
+    NULL                  AS profile_picture,
     NOW()                 AS created_at,
     'USER'                AS role;
     

--- a/SPs/UserSps/GetResidenceProofs.sql
+++ b/SPs/UserSps/GetResidenceProofs.sql
@@ -28,7 +28,7 @@ BEGIN
     id,
     user_id             AS userId,
     proof_message       AS proofMessage,
-    proof_image_b64     AS proofImageB64,
+    proof_image_url     AS proofImageUrl,
     created_at          AS createdAt
   FROM residence_proofs
   WHERE (p_UserId IS NULL OR user_id = p_UserId)

--- a/SPs/UserSps/GetResidenceProofs.sql
+++ b/SPs/UserSps/GetResidenceProofs.sql
@@ -28,7 +28,7 @@ BEGIN
     id,
     user_id             AS userId,
     proof_message       AS proofMessage,
-    proof_image_url     AS proofImageUrl,
+    proof_doc_url       AS proofDocUrl,
     created_at          AS createdAt
   FROM residence_proofs
   WHERE (p_UserId IS NULL OR user_id = p_UserId)

--- a/SPs/UserSps/SetEmailConfirmationToken.sql
+++ b/SPs/UserSps/SetEmailConfirmationToken.sql
@@ -4,12 +4,16 @@ DELIMITER //
   SP: SetEmailConfirmationToken
   Propósito: Insertar o reemplazar el token de confirmación
              en email_confirmation_tokens dado un user_id.
+             Guarda también datos de prueba de residencia
+             (mensaje y URL de la imagen).
 ----------------------------------------------------------------*/
 DROP PROCEDURE IF EXISTS SetEmailConfirmationToken//
 
 CREATE PROCEDURE SetEmailConfirmationToken(
-  IN p_UserId BIGINT,
-  IN p_Token  VARCHAR(100)
+  IN p_UserId        BIGINT,
+  IN p_Token         VARCHAR(100),
+  IN p_ProofMessage  VARCHAR(500),
+  IN p_ProofImageUrl VARCHAR(1000)
 )
 BEGIN
   -- Manejador de errores: rollback y señal en caso de excepción
@@ -30,17 +34,23 @@ BEGIN
       SET MESSAGE_TEXT = 'Usuario inexistente';
   END IF;
 
+  -- 2) Validar que al menos haya mensaje o imagen
+  IF p_ProofMessage IS NULL AND p_ProofImageUrl IS NULL THEN
+    SIGNAL SQLSTATE '45000'
+      SET MESSAGE_TEXT = 'Se requiere mensaje o imagen para la prueba de residencia';
+  END IF;
+
   START TRANSACTION;
 
-    -- 2) Eliminar token previo si existe
+    -- 3) Eliminar token previo si existe
     DELETE FROM email_confirmation_tokens
      WHERE user_id = p_UserId;
 
-    -- 3) Insertar nuevo token
+    -- 4) Insertar nuevo token con datos de prueba
     INSERT INTO email_confirmation_tokens (
-      user_id, token, created_at
+      user_id, token, proof_message, proof_image_url, created_at
     ) VALUES (
-      p_UserId, p_Token, NOW()
+      p_UserId, p_Token, p_ProofMessage, p_ProofImageUrl, NOW()
     );
 
   COMMIT;

--- a/SPs/UserSps/SetEmailConfirmationToken.sql
+++ b/SPs/UserSps/SetEmailConfirmationToken.sql
@@ -5,7 +5,7 @@ DELIMITER //
   Propósito: Insertar o reemplazar el token de confirmación
              en email_confirmation_tokens dado un user_id.
              Guarda también datos de prueba de residencia
-             (mensaje y URL de la imagen).
+             (mensaje y URL del documento).
 ----------------------------------------------------------------*/
 DROP PROCEDURE IF EXISTS SetEmailConfirmationToken//
 
@@ -13,7 +13,7 @@ CREATE PROCEDURE SetEmailConfirmationToken(
   IN p_UserId        BIGINT,
   IN p_Token         VARCHAR(100),
   IN p_ProofMessage  VARCHAR(500),
-  IN p_ProofImageUrl VARCHAR(1000)
+  IN p_ProofDocUrl   VARCHAR(1000)
 )
 BEGIN
   -- Manejador de errores: rollback y señal en caso de excepción
@@ -34,10 +34,10 @@ BEGIN
       SET MESSAGE_TEXT = 'Usuario inexistente';
   END IF;
 
-  -- 2) Validar que al menos haya mensaje o imagen
-  IF p_ProofMessage IS NULL AND p_ProofImageUrl IS NULL THEN
+  -- 2) Validar que al menos haya mensaje o documento
+  IF p_ProofMessage IS NULL AND p_ProofDocUrl IS NULL THEN
     SIGNAL SQLSTATE '45000'
-      SET MESSAGE_TEXT = 'Se requiere mensaje o imagen para la prueba de residencia';
+      SET MESSAGE_TEXT = 'Se requiere mensaje o documento para la prueba de residencia';
   END IF;
 
   START TRANSACTION;
@@ -48,9 +48,9 @@ BEGIN
 
     -- 4) Insertar nuevo token con datos de prueba
     INSERT INTO email_confirmation_tokens (
-      user_id, token, proof_message, proof_image_url, created_at
+      user_id, token, proof_message, proof_doc_url, created_at
     ) VALUES (
-      p_UserId, p_Token, p_ProofMessage, p_ProofImageUrl, NOW()
+      p_UserId, p_Token, p_ProofMessage, p_ProofDocUrl, NOW()
     );
 
   COMMIT;

--- a/SPs/UserSps/VerifyEmail.sql
+++ b/SPs/UserSps/VerifyEmail.sql
@@ -3,11 +3,11 @@ DELIMITER //
 /*---------------------------------------------------------------
   SP: VerifyEmail
   Propósito: Validar token de verificación desde email_confirmation_tokens,
-    marcar email verificado en users y anular el token.
+    marcar email verificado en users y crear prueba de residencia.
     - Verifica que el token exista en email_confirmation_tokens.
     - Si el email ya estaba verificado, arroja error específico.
     - Marca verified_email = 1, actualiza status = 1 si verified_residence = 1.
-    - Elimina el token de email_confirmation_tokens.
+    - Inserta la prueba de residencia y elimina el token.
 ----------------------------------------------------------------*/
 DROP PROCEDURE IF EXISTS VerifyEmail//
 
@@ -17,10 +17,12 @@ CREATE PROCEDURE VerifyEmail(
 BEGIN
   DECLARE v_UserId          BIGINT;
   DECLARE v_AlreadyVerified TINYINT;
+  DECLARE v_ProofMessage    VARCHAR(500);
+  DECLARE v_ProofImageUrl   VARCHAR(1000);
 
-  -- 1) Buscar el user_id en email_confirmation_tokens
-  SELECT user_id
-    INTO v_UserId
+  -- 1) Buscar el user_id y datos de prueba en email_confirmation_tokens
+  SELECT user_id, proof_message, proof_image_url
+    INTO v_UserId, v_ProofMessage, v_ProofImageUrl
     FROM email_confirmation_tokens
    WHERE token = p_Token
    LIMIT 1;
@@ -58,7 +60,14 @@ BEGIN
       SET MESSAGE_TEXT = 'Error al actualizar estado de verificación de email';
   END IF;
 
-  -- 4) Eliminar el token usado
+  -- 4) Crear registro de prueba de residencia
+  INSERT INTO residence_proofs (
+    user_id, proof_message, proof_image_url, created_at
+  ) VALUES (
+    v_UserId, v_ProofMessage, v_ProofImageUrl, NOW()
+  );
+
+  -- 5) Eliminar el token usado
   DELETE FROM email_confirmation_tokens
    WHERE token = p_Token;
   IF ROW_COUNT() = 0 THEN
@@ -69,7 +78,7 @@ BEGIN
 
   COMMIT;
 
-  -- 5) Respuesta exitosa
+  -- 6) Respuesta exitosa
   SELECT
     0 AS code,
     'Email verificado correctamente' AS description;

--- a/SPs/UserSps/VerifyEmail.sql
+++ b/SPs/UserSps/VerifyEmail.sql
@@ -18,11 +18,11 @@ BEGIN
   DECLARE v_UserId          BIGINT;
   DECLARE v_AlreadyVerified TINYINT;
   DECLARE v_ProofMessage    VARCHAR(500);
-  DECLARE v_ProofImageUrl   VARCHAR(1000);
+  DECLARE v_ProofDocUrl     VARCHAR(1000);
 
   -- 1) Buscar el user_id y datos de prueba en email_confirmation_tokens
-  SELECT user_id, proof_message, proof_image_url
-    INTO v_UserId, v_ProofMessage, v_ProofImageUrl
+  SELECT user_id, proof_message, proof_doc_url
+    INTO v_UserId, v_ProofMessage, v_ProofDocUrl
     FROM email_confirmation_tokens
    WHERE token = p_Token
    LIMIT 1;
@@ -62,9 +62,9 @@ BEGIN
 
   -- 4) Crear registro de prueba de residencia
   INSERT INTO residence_proofs (
-    user_id, proof_message, proof_image_url, created_at
+    user_id, proof_message, proof_doc_url, created_at
   ) VALUES (
-    v_UserId, v_ProofMessage, v_ProofImageUrl, NOW()
+    v_UserId, v_ProofMessage, v_ProofDocUrl, NOW()
   );
 
   -- 5) Eliminar el token usado

--- a/Tables/email_confirmation_tokens.sql
+++ b/Tables/email_confirmation_tokens.sql
@@ -1,14 +1,18 @@
 DROP TABLE IF EXISTS email_confirmation_tokens;
 
 CREATE TABLE email_confirmation_tokens (
-  id          BIGINT AUTO_INCREMENT PRIMARY KEY,
-  user_id     BIGINT            NOT NULL,
-  token       VARCHAR(100)      NOT NULL UNIQUE,
-  created_at  DATETIME          NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  
+  id              BIGINT AUTO_INCREMENT PRIMARY KEY,
+  user_id         BIGINT            NOT NULL,
+  token           VARCHAR(100)      NOT NULL UNIQUE,
+  proof_message   VARCHAR(500),
+  proof_image_url VARCHAR(1000),
+  created_at      DATETIME          NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
   CONSTRAINT fk_email_token_user
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-  
+  CONSTRAINT chk_email_token_proof_not_both_null
+    CHECK (proof_message IS NOT NULL OR proof_image_url IS NOT NULL),
+
     INDEX idx_email_token (token)
   ,INDEX idx_email_tokens_user_id (user_id)
   );

--- a/Tables/email_confirmation_tokens.sql
+++ b/Tables/email_confirmation_tokens.sql
@@ -5,13 +5,13 @@ CREATE TABLE email_confirmation_tokens (
   user_id         BIGINT            NOT NULL,
   token           VARCHAR(100)      NOT NULL UNIQUE,
   proof_message   VARCHAR(500),
-  proof_image_url VARCHAR(1000),
+  proof_doc_url   VARCHAR(1000),
   created_at      DATETIME          NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
   CONSTRAINT fk_email_token_user
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
   CONSTRAINT chk_email_token_proof_not_both_null
-    CHECK (proof_message IS NOT NULL OR proof_image_url IS NOT NULL),
+    CHECK (proof_message IS NOT NULL OR proof_doc_url IS NOT NULL),
 
     INDEX idx_email_token (token)
   ,INDEX idx_email_tokens_user_id (user_id)

--- a/Tables/residence_proofs.sql
+++ b/Tables/residence_proofs.sql
@@ -4,7 +4,7 @@ CREATE TABLE residence_proofs (
   id               BIGINT AUTO_INCREMENT PRIMARY KEY,
   user_id          BIGINT            NOT NULL,
   proof_message    VARCHAR(500),
-  proof_image_url  VARCHAR(1000),
+  proof_doc_url    VARCHAR(1000),
   created_at       DATETIME          NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
   CONSTRAINT fk_residence_proofs_user
@@ -14,5 +14,5 @@ CREATE TABLE residence_proofs (
   CONSTRAINT uq_residence_proofs_user UNIQUE (user_id),
 
   CONSTRAINT chk_proof_not_both_null
-    CHECK (proof_message IS NOT NULL OR proof_image_url IS NOT NULL)
+    CHECK (proof_message IS NOT NULL OR proof_doc_url IS NOT NULL)
 );

--- a/Tables/residence_proofs.sql
+++ b/Tables/residence_proofs.sql
@@ -4,7 +4,7 @@ CREATE TABLE residence_proofs (
   id               BIGINT AUTO_INCREMENT PRIMARY KEY,
   user_id          BIGINT            NOT NULL,
   proof_message    VARCHAR(500),
-  proof_image_b64  LONGTEXT,
+  proof_image_url  VARCHAR(1000),
   created_at       DATETIME          NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
   CONSTRAINT fk_residence_proofs_user
@@ -14,5 +14,5 @@ CREATE TABLE residence_proofs (
   CONSTRAINT uq_residence_proofs_user UNIQUE (user_id),
 
   CONSTRAINT chk_proof_not_both_null
-    CHECK (proof_message IS NOT NULL OR proof_image_b64 IS NOT NULL)
+    CHECK (proof_message IS NOT NULL OR proof_image_url IS NOT NULL)
 );


### PR DESCRIPTION
## Summary
- store residence proof message and image URL with email confirmation token
- create residence proof entry when verifying email
- switch residence proof storage to image URLs and drop proof handling from CreateUser

## Testing
- `rg proof_image_url -n`


------
https://chatgpt.com/codex/tasks/task_e_689526c873cc8330be3fbffd952fb715